### PR TITLE
Fixes README minimal example and send string values to `core.setOutput`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: action_with_json_output
-        run: 'echo ::set-output name=data::{ "foo": { "bar":"baz" } }'
+        run: 'echo ::set-output name=data::{ \"foo\": { \"bar_number\":0, \"bar_str\":\"baz\" } }'
+      - uses: actions/checkout@v2
       - id: data
         uses: gr2m/get-json-paths-action@v1.x
         with:
           json: ${{ steps.action_with_json_output.outputs.data }}
-          bar: "foo.bar"
-      - run: "echo bar is ${{ steps.data.outputs.bar }}"
+          foo: "foo"
+          bar_number: "foo.bar_number"
+          bar_str: "foo.bar_str"
+          bar_undefined: "foo.bar[0]"
+      - run: |
+          echo "foo is '${{ steps.data.outputs.foo }}'"
+          echo "bar_number is '${{ steps.data.outputs.bar_number }}'"
+          echo "bar_str is '${{ steps.data.outputs.bar_str }}'"
+          echo "bar_undefined is '${{ steps.data.outputs.bar_undefined }}'"
 ```
 
 Example with [`octokit/request-action`](https://github.com/octokit/request-action/)

--- a/dist/index.js
+++ b/dist/index.js
@@ -67,8 +67,9 @@ try {
 
   for (const [name, path] of Object.entries(paths)) {
     const value = get(jsonParsed, path);
-    core.debug(`setting output ${name} to ${value} using "${path}"`);
-    core.setOutput(name, value);
+    const strValue = JSON.stringify(value);
+    core.debug(`setting output ${name} to "${strValue}" (${typeof value}) using "${path}"`);
+    core.setOutput(name, strValue);
   }
 } catch (error) {
   core.setFailed(error);

--- a/index.js
+++ b/index.js
@@ -12,8 +12,9 @@ try {
 
   for (const [name, path] of Object.entries(paths)) {
     const value = get(jsonParsed, path);
-    core.debug(`setting output ${name} to ${value} using "${path}"`);
-    core.setOutput(name, value);
+    const strValue = JSON.stringify(value);
+    core.debug(`setting output ${name} to "${strValue}" (${typeof value}) using "${path}"`);
+    core.setOutput(name, strValue);
   }
 } catch (error) {
   core.setFailed(error);


### PR DESCRIPTION
Closes #9

Before ba9ed1bf108b8a09edecd8d9a991a4ede654e986:
![workflow before](https://user-images.githubusercontent.com/13461315/76263880-db012080-623e-11ea-9a34-5549bce11aac.png)

After:
![workflow after](https://user-images.githubusercontent.com/13461315/76263931-9b363b00-6236-11ea-8d06-36c9c1bb1d25.png)